### PR TITLE
Small improvement to avoid forked grep process

### DIFF
--- a/bashmount
+++ b/bashmount
@@ -476,9 +476,7 @@ list_devices() {
         # (eg, internal storage on some portable media devices) then it should
         # be visible.
         elif [[ "${info_type}" == 'disk' ]]; then
-            printf '%s\n' "${all[@]}" \
-                | grep -ow -E "^${devname}[0-9]+" >/dev/null 2>&1
-            (( $? )) || continue
+            [[ "${all[@]}" =~ ${devname}1 ]] && continue
             if info_removable "${devname}"; then
                 removable[${#removable[*]}]="${devname}"
             else


### PR DESCRIPTION
In the function "list_devices", replace grep with regex when looking for partitions on a device.
Only the presence of /dev/sda1 has to be checked, as /dev/sda2 implies the presence of /dev/sda1.
This could be improved further by only checking if the next array element is /dev/sda1, as the array is already sorted.
