### PR TITLE
Offer one-shot cmd behaviour via 'loop' config

### DIFF
--- a/bashmount
+++ b/bashmount
@@ -72,6 +72,7 @@ declare -i custom6_show=0
 declare -i run_post_mount=0
 declare -i run_post_unmount=0
 declare -a blacklist=()
+declare -i loop=1
 
 mount_command() {
     if (( udisks == 0 )); then
@@ -447,7 +448,10 @@ action_mount() {
             error "${1} could not be mounted."
         fi
     fi
-    enter_to_continue
+    if (( loop ))
+    then
+      enter_to_continue
+    fi
 }
 
 action_open() {
@@ -468,7 +472,10 @@ action_open() {
     msg "Opening ${1} ..."
     printf '\n'
     filemanager "$(info_mountpath "${1}")"
-    enter_to_continue
+    if (( loop ))
+    then
+      enter_to_continue
+    fi
 }
 
 action_unmount() {
@@ -486,7 +493,10 @@ action_unmount() {
     else
         error "${1} is not mounted."
     fi
-    enter_to_continue
+    if (( loop ))
+    then
+      enter_to_continue
+    fi
 }
 # }}}
 
@@ -753,9 +763,17 @@ declare -i device_number=
 declare -a mounted=()
 declare -a listed=()
 
-while true; do
-    clear
-    list_devices
-    (( show_commands )) && print_commands
-    select_action
-done
+if (( loop ))
+then
+  while true; do
+      clear
+      list_devices
+      (( show_commands )) && print_commands
+      select_action
+  done
+else
+  clear
+  list_devices
+  (( show_commands )) && print_commands
+  select_action
+fi

--- a/bashmount.conf
+++ b/bashmount.conf
@@ -36,6 +36,10 @@
 # The strings are matched using "grep -E".
 #blacklist=()
 
+# Set whether to exit after just one action or loop and prompt continuously
+# Default is to loop, uncomment the line below to enable one-shot behaviour.
+#loop='0'
+
 ###
 ### This example will match any device with "Photosmart" in any field.
 ### blacklist=( 'Photosmart' )


### PR DESCRIPTION
I found escaping from this script excessively verbose most of the time. This PR offers one-shot style actions via a new 'loop' config flag. The original behaviour remains the default.
