### PR TITLE
Add XDG .desktop file

### DIFF
--- a/bashmount.desktop
+++ b/bashmount.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=bashmount
+GenericName=Terminal Disk Mounter
+Comment=
+Exec=bashmount
+Terminal=true
+StartupWMClass=bashmount
+Type=Application
+Keywords=Disk;Mount;Automount;CLI;
+Icon=drive-removable-media
+Categories=Utility
+StartupNotify=true


### PR DESCRIPTION
Once installed into /usr/share/applications or
~/.local/share/applications, this can be used to launch
a terminal running `bashmount` through a GUI like Rofi,
Gnome, etc.

This can be helpful if you forget the name of your mount utility,
or if you wanted to launch a new terminal window for bashmount
anyway.
