### PR TITLE
Allow devices to be filtered by PARTUUID or WWN

### DIFF
--- a/bashmount
+++ b/bashmount
@@ -586,7 +586,7 @@ list_devices() {
     for devname in "${all[@]}"; do
         # Hide excluded devices.
         for string in "${exclude[@]}"; do
-            lsblk -dPno NAME,TYPE,FSTYPE,LABEL,MOUNTPOINT,PARTLABEL,UUID "$devname" \
+            lsblk -dPno NAME,TYPE,FSTYPE,LABEL,MOUNTPOINT,PARTLABEL,UUID,PARTUUID,WWN "$devname" \
                 | grep -E "$string" >/dev/null 2>&1
             (( $? )) || continue 2
         done

--- a/bashmount.conf
+++ b/bashmount.conf
@@ -47,6 +47,8 @@
 ### exclude+=( 'LABEL="secret"' )
 ### exclude+=( 'MOUNTPOINT="/"' )
 ### exclude+=( 'UUID="0c4d6d9c-87a2-4579-b2ae-35b0790c718a"' )
+### exclude+=( 'PARTUUID="5b99bf8a-1abc-4ea3-8e50-9006a8552a07"' )
+### exclude+=( 'WWN="0x500277a4100c4e21"' )
 ###
 
 # Set filemanager command to use when performing the "open" command. The mount


### PR DESCRIPTION
Hello, thanks for this great tool.  I ran into an issue today where I couldn't filter certain zfs partitions from the bashmount device list; for some reason some zfs vdevs are filtered by `FSTYPE="zfs_member"` but others aren't.  Also `lsblk` was returning blanks for most of the other built-in fields, and I didn't want to use `NAME=sda3` because those names shift around if I add/remove drives.  However, `lsblk` was consistently giving good data for `PARTUUID` and `WWN` so I added those to the filter in `list_devices()`.